### PR TITLE
✨ 광고문구 자동생성 api, 이미지 자동생성 api 연결

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,11 @@
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "axios": "^1.7.7",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-icons": "^5.3.0",
-        "react-scripts": "5.0.1",
+        "react-scripts": "^5.0.1",
         "styled-components": "^6.1.13",
         "web-vitals": "^2.1.4"
       }
@@ -5360,6 +5361,29 @@
       "integrity": "sha512-Mr2ZakwQ7XUAjp7pAwQWRhhK8mQQ6JAaNWSjmjxil0R8BPioMtQsTLOolGYkji1rcL++3dCqZA3zWqpT+9Ew6g==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -14620,6 +14644,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/psl": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -6,10 +6,11 @@
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^1.7.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-icons": "^5.3.0",
-    "react-scripts": "5.0.1",
+    "react-scripts": "^5.0.1",
     "styled-components": "^6.1.13",
     "web-vitals": "^2.1.4"
   },
@@ -36,5 +37,6 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  }
+  },
+  "proxy": "http://127.0.0.1:8080"
 }

--- a/package.json.rej
+++ b/package.json.rej
@@ -1,0 +1,9 @@
+diff a/package.json b/package.json	(rejected hunks)
+@@ -36,6 +36,5 @@
+       "last 1 firefox version",
+       "last 1 safari version"
+     ]
+-  },
+-    "proxy": "http://127.0.0.1:8080"
++  }
+ }

--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,8 @@ import MenuBar from './components/MenuBar';
 import AIGenPage from './pages/AIGenPage';  // AI 생성 페이지 임포트
 import OtherPage from './pages/OtherPage';  // 예시로 다른 페이지 추가
 
+// npm start
+
 const App = () => {
   const [activePage, setActivePage] = useState('AIGen');  // 기본 페이지는 AI 생성
 
@@ -33,3 +35,7 @@ const App = () => {
 };
 
 export default App;
+
+
+
+

--- a/src/components/ImageDisplay.js
+++ b/src/components/ImageDisplay.js
@@ -1,9 +1,8 @@
-// ImageDisplay.js
 import React from 'react';
 import styled from 'styled-components';
 
 const ImageContainer = styled.div`
-  width: flex;
+  width: 100%;
   height: 500px;
   background-color: #f0f0f0;
   display: flex;
@@ -14,7 +13,11 @@ const ImageContainer = styled.div`
 const ImageDisplay = ({ imageSrc }) => {
   return (
     <ImageContainer>
-      {imageSrc ? <img src={imageSrc} alt="Selected" style={{ maxHeight: '100%', maxWidth: '100%' }} /> : '이미지를 선택하세요'}
+      {imageSrc ? (
+        <img src={imageSrc} alt="Generated" style={{ maxHeight: '100%', maxWidth: '100%' }} />
+      ) : (
+        '이미지를 선택하세요'
+      )}
     </ImageContainer>
   );
 };

--- a/src/components/KeywordInput.js
+++ b/src/components/KeywordInput.js
@@ -62,23 +62,27 @@ const CompleteButton = styled.button`
   }
 `;
 
-const KeywordInput = () => {
+const KeywordInput = ({ onComplete }) => {
   const [keywords, setKeywords] = useState([]);
-  const [currentKeyword, setCurrentKeyword] = useState('');  // 입력된 키워드를 관리
+  const [currentKeyword, setCurrentKeyword] = useState('');
 
   const handleInputChange = (e) => {
-    setCurrentKeyword(e.target.value);  // 입력 값 업데이트
+    setCurrentKeyword(e.target.value);
   };
 
   const addKeyword = () => {
     if (currentKeyword.trim() !== '') {
-      setKeywords([...keywords, currentKeyword]);  // 키워드 리스트에 추가
-      setCurrentKeyword('');  // 입력 필드 초기화
+      const newKeywords = [...keywords, currentKeyword];
+      setKeywords(newKeywords);
+      setCurrentKeyword('');
+      onComplete(newKeywords); // 상위 컴포넌트에 키워드 업데이트 알림
     }
   };
 
   const removeKeyword = (index) => {
-    setKeywords(keywords.filter((_, i) => i !== index));  // 키워드 제거
+    const newKeywords = keywords.filter((_, i) => i !== index);
+    setKeywords(newKeywords);
+    onComplete(newKeywords); // 상위 컴포넌트에 키워드 업데이트 알림
   };
 
   return (

--- a/src/components/MessageGenerate.js
+++ b/src/components/MessageGenerate.js
@@ -1,0 +1,48 @@
+// MessageGenerate.js
+import React, { useState } from 'react';
+import styled from 'styled-components';
+
+const Container = styled.div`
+  padding: 10px;
+`;
+
+const InputField = styled.input`
+  width: 100%;
+  padding: 5px;
+  margin-bottom: 10px;
+  border: 1px solid #ccc;
+`;
+
+const GenerateButton = styled.button`
+  padding: 10px;
+  background-color: #9B30FF;
+  color: white;
+  border: none;
+  cursor: pointer;
+  width: 100%;
+
+  &:hover {
+    background-color: #6a1bb3;
+  }
+`;
+
+const MessageGenerate = ({ onGenerate }) => {
+  const [prompt, setPrompt] = useState('');
+
+  const handleInputChange = (e) => setPrompt(e.target.value);
+
+  return (
+    <Container>
+      <InputField
+        placeholder="프롬프트 입력"
+        value={prompt}
+        onChange={handleInputChange}
+      />
+      <GenerateButton onClick={() => onGenerate(prompt)}>
+        GPT 자동 생성
+      </GenerateButton>
+    </Container>
+  );
+};
+
+export default MessageGenerate;

--- a/src/components/MessageInput.js
+++ b/src/components/MessageInput.js
@@ -1,8 +1,8 @@
-import React, { useState } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 
 const Container = styled.div`
-  width: flex;
+  width: 100%;
   padding: 10px;
 `;
 
@@ -33,22 +33,26 @@ const Button = styled.button`
   }
 `;
 
-const MessageInput = () => {
-  const [message, setMessage] = useState('');
+const MessageInput = ({ value, onPromptChange, onGenerateImage }) => {
+  const handlePromptChange = (e) => {
+    onPromptChange(e.target.value); // 부모로부터 받은 함수 호출
+  };
 
-  const handleInputChange = (e) => {
-    setMessage(e.target.value);
+  const handleGenerateImage = () => {
+    if (onGenerateImage) {
+      onGenerateImage(); // 이미지 생성 핸들러 호출
+    }
   };
 
   return (
     <Container>
       <TextArea
-        value={message}
-        onChange={handleInputChange}
+        value={value} // 부모로부터 받은 value 사용
+        onChange={handlePromptChange}
         placeholder="메시지를 입력해주세요."
       />
-      <ByteCount>{message.length}/2000byte</ByteCount>
-      <Button onClick={() => console.log('AI 자동 생성 클릭됨')}>AI 자동 생성</Button>
+      <ByteCount>{value.length}/2000byte</ByteCount>
+      <Button onClick={handleGenerateImage}>AI 자동 생성</Button>
     </Container>
   );
 };

--- a/src/pages/AIGenPage.js
+++ b/src/pages/AIGenPage.js
@@ -1,32 +1,75 @@
 import React, { useState } from 'react';
 import MessageInput from '../components/MessageInput';
+import MessageGenerate from '../components/MessageGenerate';
 import KeywordInput from '../components/KeywordInput';
 import ResultDisplay from '../components/ResultDisplay';
 import ImageDisplay from '../components/ImageDisplay';
 import PageTitle from '../components/PageTitle';
+import axios from 'axios';
 
 const AIGenPage = () => {
-  const [imageSrc, setImageSrc] = useState(null);
+  const [prompt, setPrompt] = useState(''); // 프롬프트 상태
+  const [keywords, setKeywords] = useState([]); // 키워드 상태 (배열로 변경)
+  const [generatedMessage, setGeneratedMessage] = useState(''); // 생성된 메시지 상태
+  const [imageSrc, setImageSrc] = useState(''); // 생성된 이미지의 소스를 저장
+
+  const handleGenerateMessage = async (newPrompt) => {
+    setPrompt(newPrompt); // 프롬프트 업데이트
+    try {
+      const response = await axios.post('/GPT/api/create-message', {
+        mood: '알아서 결정',
+        target: '알아서 결정',
+        product: '알아서 결정',
+        keyword: keywords.join(', '), // 키워드를 쉼표로 구분하여 사용
+        prompt: newPrompt
+      });
+
+      if (response.status === 200) {
+        console.log(response.data); // 콘솔에 응답 데이터 출력
+        setGeneratedMessage(response.data); // 생성된 메시지를 상태에 저장
+      }
+    } catch (error) {
+      console.error("메시지 생성 오류:" + error);
+    }
+  };
+
+  // 이미지 생성 함수
+  const handleGenerateImage = async () => {
+    try {
+      const response = await axios.post('/SD/api/create-image', {
+        initImageURL: '', // 초기 이미지 URL, 나중에 바꿔야 됨
+        prompt: prompt // 프롬프트 사용
+      });
+
+      if (response.status === 200) {
+        setImageSrc(response.data.imageURL); // 응답으로 받은 이미지 URL 설정
+      }
+    } catch (error) {
+      console.error("이미지 생성 오류:" + error);
+    }
+  };
 
   return (
-    <div style={{ display: 'flex', width: '100%', height: '100%'}}>
-
-      {/* 메시지 입력 */}
+    <div style={{ display: 'flex', width: '100%', height: '100%' }}>
       <div style={{ width: '25%', padding: '10px' }}>
-        <PageTitle /> <br></br>
-        <MessageInput />
+        <PageTitle />
+        <br />
+        <MessageGenerate onGenerate={handleGenerateMessage} />
+        {/* MessageInput에 generatedMessage와 이미지 생성 핸들러 전달 */}
+        <MessageInput 
+          value={generatedMessage} 
+          onPromptChange={setGeneratedMessage} // 수정된 메시지 상태 업데이트
+          onGenerateImage={handleGenerateImage} 
+        />
       </div>
 
-      {/* 핵심 키워드 */}
       <div style={{ width: '50%', height: '100%', padding: '10px' }}>
-      <ImageDisplay imageSrc={imageSrc} />
-        <KeywordInput />
+        <ImageDisplay imageSrc={imageSrc} /> {/* 이미지 소스 전달 */}
+        <KeywordInput onComplete={setKeywords} /> {/* 키워드 상태 업데이트 */}
       </div>
 
-      {/* 생성 결과 */}
       <div style={{ width: '25%', padding: '10px' }}>
         <ResultDisplay />
-        
       </div>
     </div>
   );


### PR DESCRIPTION
실수로 PR없이 올려서 다시 올립니다 ㅠㅠ

## ✨ 광고문구 자동생성 api, 이미지 자동생성 api 연결 및 그에 맞게  ui 부분 수정. proxy 서버 설정 #3 

## 🔘Part

- [x] FE
- [ ] BE
- [ ] AI
  <br/>

## 🔎 작업 내용

- GPT로 광고문구 생성하는 api 연결: 현 인자 (`keyword`, `prompt`)
- 이미지 자동생성 api 연결 : 현 인자 (`prompt`)
- GPT에게 요청할 프롬프트 넣을 UI와 버튼 추가
- CORS 관련 문제 우회를 위한 proxy 서버 설정
- 즉 키워드랑 프롬프트 넣고 gpt한테 던져서 광고 메시지 받아오고, 그걸 sd한테 쏴보는 과정.

참고로 프록시 주소를 `"proxy": "http://127.0.0.1:8080"`로 해놔서 직접 돌려보실 분들은 서버도 로컬에서 돌리거나, 루트의 `package.json` 가서 해당 ip 를 aws에서 준 ip로 바꾸시면 됩니다

  <br/>

## 이미지 첨부

![test](https://github.com/user-attachments/assets/f0817a87-7978-4f4f-ba1c-e616b41dcb01)


<br/>

## 🔧 TO DO

- SD쪽 api가 완전한 상태가 아닙니다. 500 에러가 뜨는데, 이전에 디코에서 언급했던 문제 관련일 수 있기에 서버 수정을 기다렸다가 다시 시도 예정.
- 광고문구 api 인자 중 `mood`, `target`, `product`에 넣을 값을 받을 ui 생성
- 받은 값 api에 연동하기 (현재는 `알아서 결정`으로 하드코딩된 상태)
- 마찬가지로 이미지 자동생성 인자에 넣을 `initImageURL` 설정
- CORS 문제를 proxy 서버로 계속 우회할 건지, 백에서 관련 설정을 할 건지 결정

  <br/>

## ➕ 이슈 링크

- [Front #3 ](https://github.com/PreCapstone/Front/issues/3)

<br/>
